### PR TITLE
Fix: double border and too small card

### DIFF
--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -43,7 +43,7 @@
 }
 
 @media screen and (max-width: 425px) {
-  .card {
+  .card canvas {
     border: 2px solid var(--main-color);
   }
 }

--- a/src/components/Tutorial/Tutorial.css
+++ b/src/components/Tutorial/Tutorial.css
@@ -43,6 +43,8 @@
 
 @media screen and (max-width: 768px) {
   .tutorial {
+    --tutorial-card-width: var(--card-width);
+    --tutorial-card-height: var(--card-height);
     display: block;
   }
 


### PR DESCRIPTION
- [이전의 Card의 border를 수정하는 작업](https://github.com/SET-GEMS/set-gems-client/pull/60)에서 놓친 mediaquery에서의 border 속성 부분 수정
- Tutorial의 Card의 크기가 너무 작아지는 것을 수정