### PR TITLE
Fix: 카드가 마운트 되는 순간 커지는 현상

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const cacheName = "set-gems-v3";
+const cacheName = "set-gems-v4";
 const contentToCache = [
   "/index.html",
   "/favicon.ico",

--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -11,6 +11,8 @@
 }
 
 .card canvas {
+  width: 100%;
+  height: 100%;
   border: 5px solid var(--main-color);
   border-radius: 5px;
   box-shadow: 1px 1px gray;
@@ -40,12 +42,6 @@
 .card img {
   width: 50%;
   transform: rotate(10deg);
-}
-
-@media screen and (max-width: 425px) {
-  .card canvas {
-    border: 2px solid var(--main-color);
-  }
 }
 
 @keyframes blink {

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -30,8 +30,6 @@ function Card({
 
     const canvas = canvasRef.current;
 
-    canvas.style.width = "100%";
-    canvas.style.height = "100%";
     canvas.width = canvas.offsetWidth;
     canvas.height = canvas.offsetHeight;
 

--- a/src/components/Guide/Guide.css
+++ b/src/components/Guide/Guide.css
@@ -51,9 +51,9 @@
 }
 
 .example .card {
-  box-sizing: border-box;
-  animation: none;
+  box-sizing: content-box;
   margin: 10px 2px 0 2px;
+  cursor: auto;
 }
 
 .example .card.new {
@@ -69,6 +69,7 @@
   border: 1px solid var(--main-color);
   padding: 0 5px;
   margin: 2px;
+  cursor: pointer;
 }
 
 .properties span.selected {

--- a/src/components/Guide/index.js
+++ b/src/components/Guide/index.js
@@ -29,9 +29,9 @@ function Guide() {
     };
 
     return (
-      <div className="example-card" key={`${selectedProperty}${i}`} >
+      <div className="example-card" key={JSON.stringify(cardProps)} >
         <p>{CARD_PROPERTY_KOR[cardProps[selectedProperty]]}</p>
-        <Card {...cardProps} />
+        <Card state="" {...cardProps} />
       </div>
     );
   });


### PR DESCRIPTION
- canvas의 크기가 Card의 크기와 같도록 canvas.style.width와 canvas.style.height를 마운트 후에 조작하게끔 로직이 구성되어있었는데 크기를 조작하기 전 아주 짧은 시간동안 canvas의 기본 크기로 보여지면서 깜박거리는 듯 보이는 것이었습니다. css에서 canvas의 기본 크기 자체를 설정하여 해당 현상을 수정하였습니다.

- 카드의 크기가 작아지면서 경계선도 2px로 변경하던 것을 삭제하였습니다.

- Guide에서도 저장된 Card를 쓸 수 있도록 key값을 변경하였습니다. 
- Guide의 Card의 커서를 일반적인 커서로 바꾸고, Property버튼의 커서를 포인터로 바꾸었습니다. 